### PR TITLE
feat:conversorfile zpl to pdf e pdf to printer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "zplimpress",
+  "version": "1.0.0",
+  "description": "sistema de conversão de zpl to pdf e impressão termica",
+  "main": "index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PedroC0sta/zplimpress.git"
+  },
+  "keywords": [
+    "node",
+    "printer",
+    "thermal-printer",
+    "labelary",
+    "zpl"
+  ],
+  "author": "PedroC0sta",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/PedroC0sta/zplimpress/issues"
+  },
+  "homepage": "https://github.com/PedroC0sta/zplimpress#readme",
+  "dependencies": {
+    "chokidar": "^3.5.3",
+    "fs": "^0.0.1-security",
+    "node-thermal-printer": "^4.1.2",
+    "nodemon": "^2.0.19",
+    "pdf-to-printer": "^5.3.0",
+    "request": "^2.88.2",
+    "serialport": "^10.4.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,10 @@
-const fsp = require('fs').promises;
-const fs = require('fs');
+const fs = require('fs').promises;
 const request =  require('request');
 const ptp = require("pdf-to-printer");
 
-const { join } = require('path');
+// ptp.getPrinters().then((response) => console.log(response))
 
 var chokidar = require('chokidar');
-//path local onde será salvo as etiquetas
-const directoryPath = join(__dirname, '\etiquetas');
 // Opções da impressora
 const settings = {
   printer: "CC410Label Printer",
@@ -21,7 +18,7 @@ const settings = {
 chokidar.watch('./etiquetas').on('all', async (event, path) => {
   let etiqueta;
   if(event === 'add') {
-    etiqueta = await fsp.readFile(path,'utf-8')
+    etiqueta = await fs.readFile(path,'utf-8')
 
     //Opções da request API zpl labelary
     const options = {
@@ -35,13 +32,14 @@ chokidar.watch('./etiquetas').on('all', async (event, path) => {
       if (err) {
         return console.log(err);
       }
-      await fsp.writeFile('label.pdf', body, (err) => {
+      await fs.writeFile('label.pdf', body, (err) => {
         if (err) {
             console.log(err);
         }
     })
     try {
       await ptp.print("./label.pdf", settings)
+      await fs.unlink(path);
     } catch (err) {
       console.log(err);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,51 @@
+const fsp = require('fs').promises;
+const fs = require('fs');
+const request =  require('request');
+const ptp = require("pdf-to-printer");
+
+const { join } = require('path');
+
+var chokidar = require('chokidar');
+//path local onde será salvo as etiquetas
+const directoryPath = join(__dirname, '\etiquetas');
+// Opções da impressora
+const settings = {
+  printer: "CC410Label Printer",
+  unix: ["-o fit-to-page"],
+  win32: ['-print-settings "fit"']
+};
+
+
+
+//watch verifica se a pasta com as etiquetas teve algum arquivo adicionado
+chokidar.watch('./etiquetas').on('all', async (event, path) => {
+  let etiqueta;
+  if(event === 'add') {
+    etiqueta = await fsp.readFile(path,'utf-8')
+
+    //Opções da request API zpl labelary
+    const options = {
+      encoding: null,
+      formData: {file: etiqueta},
+      headers: { 'Accept': 'application/pdf' },
+      //url para varias etiquetas com index omitido
+      url: 'http://api.labelary.com/v1/printers/8dpmm/labels/4x6/'
+    }
+    request.post(options, async (err, res, body) => {
+      if (err) {
+        return console.log(err);
+      }
+      await fsp.writeFile('label.pdf', body, (err) => {
+        if (err) {
+            console.log(err);
+        }
+    })
+    try {
+      await ptp.print("./label.pdf", settings)
+    } catch (err) {
+      console.log(err);
+    }
+    });
+  }
+});
+


### PR DESCRIPTION
Assiste mudança no diretório "etiquetas" converte o arquivo de linguagem zpl para pdf  em seguida é realizado uma query de impressão do pdf.